### PR TITLE
fix(nuxt-styleguide-renderer-default): namespace styleguide renderer

### DIFF
--- a/packages/nuxt-styleguide-renderer-default/Icon.vue
+++ b/packages/nuxt-styleguide-renderer-default/Icon.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="single"
-    class="single-icon"
+    class="nsg-single-icon"
   >
     <img :src="iconUrl">
     {{ name }}
@@ -41,11 +41,11 @@ export default {
 
 
 <style>
-.single-icon {
+.nsg-single-icon {
   display: flex;
   align-items: center;
 }
-.single-icon img {
+.nsg-single-icon img {
   margin-right: 0.3em;
 }
 </style>

--- a/packages/nuxt-styleguide-renderer-default/component/ColorDemo.vue
+++ b/packages/nuxt-styleguide-renderer-default/component/ColorDemo.vue
@@ -1,15 +1,15 @@
 <template lang="html">
-  <div class="color-grid">
+  <div class="nsg-color-grid">
     <div
       v-for="(clr) in data"
       :key="clr.name"
-      class="color-demo"
+      class="nsg-color-demo"
     >
       <div
         :style="{backgroundColor: clr.value}"
-        class="color-field"
+        class="nsg-color-field"
       />
-      <label class="color-value">
+      <label class="nsg-color-value">
         {{ clr.value }}
       </label>
       <code>
@@ -33,22 +33,22 @@ export default {
 </script>
 
 <style lang="css">
-.color-grid{
+.nsg-color-grid{
   display: grid;
   grid-template-columns: repeat(auto-fill,minmax(200px, auto));
   grid-gap: 1em;
 }
-.color-value{
+.nsg-color-value{
   font-weight: 900;
   display: block;
   text-transform: uppercase;
 }
-.color-demo {
+.nsg-color-demo {
   grid-column-gap: 1em;
   justify-content: start;
   align-items: center;
 }
-.color-field {
+.nsg-color-field {
   width: 100%;
   height: 100px;
 }

--- a/packages/nuxt-styleguide-renderer-default/component/Component.vue
+++ b/packages/nuxt-styleguide-renderer-default/component/Component.vue
@@ -6,7 +6,7 @@
     <div
       v-for="(state) in states"
       :key="state.title"
-      class="component-demo"
+      class="nsg-component-demo"
     >
       <h4>{{ state.title }}</h4>
       <div :style="state.wrapperStyle">
@@ -99,7 +99,7 @@
 </template>
 
 <style>
-.component-demo {
+.nsg-component-demo {
   transform: translateX(1px);
 }
 </style>

--- a/packages/nuxt-styleguide-renderer-default/component/FontSizeDemo.vue
+++ b/packages/nuxt-styleguide-renderer-default/component/FontSizeDemo.vue
@@ -3,9 +3,9 @@
     <div
       v-for="(size) in data"
       :key="size.name"
-      class="font-size-demo"
+      class="nsg-font-size-demo"
     >
-      <span class="font-size-value">
+      <span class="nsg-font-size-value">
         {{ size.value }}
       </span>
       {{ size.name }}
@@ -23,11 +23,11 @@ export default {
 </script>
 
 <style lang="css">
-  .font-size-value{
+  .nsg-font-size-value{
     font-size: 30px;
     font-weight: 900;
   }
-  .font-size-demo{
+  .nsg-font-size-demo{
     font-size: 20px;
     margin-bottom: 1em;
   }

--- a/packages/nuxt-styleguide-renderer-default/component/LineHeightDemo.vue
+++ b/packages/nuxt-styleguide-renderer-default/component/LineHeightDemo.vue
@@ -3,17 +3,17 @@
     <div
       v-for="(size) in data"
       :key="size.name"
-      class="line-height-demo"
+      class="nsg-line-height-demo"
     >
-      <span class="line-height-name">
+      <span class="nsg-line-height-name">
         {{ size.name }}
       </span>
       <div
-        class="line-height-demo-box"
+        class="nsg-line-height-demo-box"
       >
         <div
           :style="{ height: size.value }"
-          class="line-height-demo-paragraph"
+          class="nsg-line-height-demo-paragraph"
         >
           The lazy dog jumps ofer the quick brown fox
         </div>
@@ -33,21 +33,21 @@ export default {
 
 <style lang="css">
 
-.line-height-name{
+.nsg-line-height-name{
   font-size: 20px;
   display: block;
 }
-.line-height-demo {
+.nsg-line-height-demo {
   display: flex;
   flex-direction: column;
   margin-bottom: 1em;
 }
 
-.line-height-demo-box {
+.nsg-line-height-demo-box {
   background: AliceBlue;
   padding: 1em 0;
 }
-.line-height-demo-paragraph{
+.nsg-line-height-demo-paragraph{
   box-sizing: border-box;
   padding: 0 1em;
   border-top: 1px solid #000;

--- a/packages/nuxt-styleguide-renderer-default/component/SgDefaultDtDemo.vue
+++ b/packages/nuxt-styleguide-renderer-default/component/SgDefaultDtDemo.vue
@@ -5,7 +5,7 @@
       v-for="(token) in data"
       :key="token.name"
     >
-      <code class="default-dt-label">
+      <code class="nsg-default-dt-label">
         {{ token.name }}:
       </code>
       <code>
@@ -29,7 +29,7 @@ export default {
 </script>
 
 <style lang="css">
-.default-dt-label {
+.nsg-default-dt-label {
   font-weight: bold
 }
 </style>

--- a/packages/nuxt-styleguide-renderer-default/frame.vue
+++ b/packages/nuxt-styleguide-renderer-default/frame.vue
@@ -61,6 +61,8 @@
 <script>
 import StyleguideNav from './nav/nav.vue'
 
+require('prismjs/themes/prism.css')
+
 export default {
   components: {
     StyleguideNav,
@@ -69,8 +71,6 @@ export default {
 </script>
 
 <style>
-@import 'prismjs/themes/prism.css';
-
 :root {
   --white: var(--theme-clr-white, #fff);
   --black: var(--theme-clr-black, #111);

--- a/packages/nuxt-styleguide-renderer-default/frame.vue
+++ b/packages/nuxt-styleguide-renderer-default/frame.vue
@@ -1,16 +1,16 @@
 <template lang="html">
-  <div class="frame">
-    <div class="sidebar__placebo">
+  <div class="nsg-frame">
+    <div class="nsg-sidebar__placebo">
       <input
-        id="toggleNav"
+        id="nsg-toggleNav"
         type="checkbox"
       >
       <label
-        for="toggleNav"
+        for="nsg-toggleNav"
         class="hamburger"
       >
         <svg
-          class="icon-closed"
+          class="nsg-icon-closed"
           width="100%"
           height="100%"
           viewBox="0 0 12 10"
@@ -26,7 +26,7 @@
           </g>
         </svg>
         <svg
-          class="icon-open"
+          class="nsg-icon-open"
           width="100%"
           height="100%"
           viewBox="0 0 11 11"
@@ -45,13 +45,14 @@
           </g>
         </svg>
       </label>
-      <div class="sidebar">
-        <div class="sidebar__content">
+      <div class="nsg-sidebar">
+        <div class="nsg-sidebar__content">
+          <h1>TESTING</h1>
           <StyleguideNav />
         </div>
       </div>
     </div>
-    <div class="content">
+    <div class="nsg-content">
       <slot />
     </div>
   </div>
@@ -103,7 +104,7 @@ body::before {
   z-index: 1337;
 }
 
-.frame {
+.nsg-frame {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
     Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   display: block;
@@ -111,7 +112,7 @@ body::before {
   width: 100vw;
 }
 
-.sidebar {
+.nsg-sidebar {
   position: absolute;
   top: 0;
   left: 0;
@@ -124,12 +125,12 @@ body::before {
   z-index: 42;
 }
 
-.sidebar__content {
+.nsg-sidebar__content {
   max-height: 100%;
   overflow: auto;
 }
 
-.content {
+.nsg-content {
   box-sizing: border-box;
   max-width: 900px;
   margin-top: 5rem;
@@ -153,27 +154,27 @@ p + h2,
 p + h3 {
   margin-top: 3rem;
 }
-.content a {
+.nsg-content a {
   color: var(--primary-color-500);
 }
 
-.content pre {
+.nsg-content pre {
   border-radius: 2px;
   padding: 0.7em;
   margin-bottom: 3rem;
 }
 
-.content p code,
-.content h1 code,
-.content h2 code,
-.content h3 code {
+.nsg-content p code,
+.nsg-content h1 code,
+.nsg-content h2 code,
+.nsg-content h3 code {
   background-color: var(--grey-200);
   border-radius: 1px;
   padding: 0.1em 0.3em;
   font-size: 1.1em;
 }
 
-.hamburger {
+.nsg-hamburger {
   display: block;
   position: relative;
   width: 32px;
@@ -184,56 +185,56 @@ p + h3 {
   color: var(--black);
 }
 
-.hamburger svg {
+.nsg-hamburger svg {
   fill-rule: evenodd;
   clip-rule: evenodd;
   stroke-linejoin: round;
   stroke-miterlimit: 1.41421;
 }
 
-.icon-closed,
-.icon-open {
+.nsg-icon-closed,
+.nsg-icon-open {
   fill: currentColor;
 }
-.icon-open {
+.nsg-icon-open {
   display: none;
 }
 
-#toggleNav {
+#nsg-toggleNav {
   opacity: 0;
   visibility: hidden;
   position: absolute;
   z-index: -1;
 }
 
-#toggleNav:checked ~ .sidebar {
+#nsg-toggleNav:checked ~ .sidebar {
   transform: translateY(0);
 }
-#toggleNav:checked ~ .hamburger {
+#nsg-toggleNav:checked ~ .hamburger {
   color: var(--white);
 }
-#toggleNav:checked ~ .hamburger .icon-closed {
+#nsg-toggleNav:checked ~ .hamburger .icon-closed {
   display: none;
 }
-#toggleNav:checked ~ .hamburger .icon-open {
+#nsg-toggleNav:checked ~ .hamburger .icon-open {
   display: block;
 }
 
 @media (min-width: 851px) {
-  .hamburger {
+  .nsg-hamburger {
     display: none;
   }
-  .frame {
+  .nsg-frame {
     display: grid;
     justify-content: start;
     grid-template-columns: 250px 1fr;
     grid-column-gap: 20px;
     padding: 0;
   }
-  .content {
+  .nsg-content {
     grid-column: 2;
   }
-  .sidebar {
+  .nsg-sidebar {
     width: var(--sidebarWidth);
     height: 100vh;
     position: fixed;
@@ -246,10 +247,10 @@ p + h3 {
 }
 
 @media (min-width: 1140px) {
-  .frame {
+  .nsg-frame {
     grid-template-columns: var(--sidebarWidth) 1fr minmax(800px, 4fr) 1fr;
   }
-  .content {
+  .nsg-content {
     grid-column: 3;
     margin-left: auto;
     margin-right: auto;

--- a/packages/nuxt-styleguide-renderer-default/layouts/nsgDefault.vue
+++ b/packages/nuxt-styleguide-renderer-default/layouts/nsgDefault.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'Default',
+  name: 'NsgDefault',
 }
 </script>

--- a/packages/nuxt-styleguide-renderer-default/nav/nav.vue
+++ b/packages/nuxt-styleguide-renderer-default/nav/nav.vue
@@ -1,33 +1,33 @@
 <template>
   <nav>
-    <ul class="nav">
+    <ul class="nsg-nav">
       <li
         v-for="(subRoutes, name) in routes"
         v-if="name !== 'Pages'"
         :key="name"
-        class="list-section"
+        class="nsg-list-section"
       >
         <h3
           v-if="name !== rootCategory"
-          class="title"
+          class="nsg-title"
         >
           <a
             v-if="findIndex(subRoutes)"
             :href="findIndex(subRoutes).path"
-            :class="`title-content ${findIndex(subRoutes).path === $route.path ? 'active' : ''}`"
+            :class="`nsg-title-content ${findIndex(subRoutes).path === $route.path ? 'nsg-active' : ''}`"
           >
             {{ name }}
           </a>
           <span
             v-else
-            class="title-content"
+            class="nsg-title-content"
           >
             {{ name }}
           </span>
         </h3>
         <ul
           v-if="name !== 'Icons'"
-          class="nav-list"
+          class="nsg-nav-list"
         >
           <li
             v-for="(route) in subRoutes"
@@ -36,7 +36,7 @@
             <a
               v-if="route.name.toLowerCase() !== 'index'"
               :href="route.path"
-              :class="`nav-item ${route.path === $route.path ? 'active' : ''}`"
+              :class="`nsg-nav-item ${route.path === $route.path ? 'nsg-active' : ''}`"
             >
               {{ route.name }}
             </a>
@@ -48,23 +48,24 @@
 </template>
 
 <style scoped>
-.nav {
+.nsg-nav {
   margin: 0 0.5rem;
   padding: 5rem 0 1rem;
   box-sizing: border-box;
 }
 
-.nav-list {
+.nsg-nav-list {
   margin: 0;
   padding: 0;
   list-style-type: none;
 }
 
-.list-section {
+.nsg-list-section {
   margin-bottom: 2rem;
+  width: 100%;
 }
 
-.title {
+.nsg-title {
   padding: 0;
   margin: 0;
   font-size: 0.9rem;
@@ -72,19 +73,19 @@
   letter-spacing: 0.05em;
 }
 
-.title a {
+.nsg-title a {
   color: var(--primary-color-500);
   text-decoration: none;
   cursor: pointer;
 }
 
-.title-content {
+.nsg-title-content {
   cursor: default;
   display: inline-block;
   padding: 0.5rem 1rem;
 }
 
-.nav-item {
+.nsg-nav-item {
   position: relative;
   display: block;
   margin: 0.25rem 0;
@@ -96,7 +97,7 @@
   cursor: pointer;
 }
 
-.nav-item::before {
+.nsg-nav-item::before {
   content: '';
   height: 100%;
   width: 4px;
@@ -108,23 +109,23 @@
   transition: opacity 200ms ease-in-out;
 }
 
-.active {
+.nsg-active {
   color: var(--secondary-color-800);
 }
 
-.active::before {
+.nsg-active::before {
   opacity: 0.6;
 }
 
-.nav-item:hover,
-.nav-item:focus,
-.nav-item:active {
+.nsg-nav-item:hover,
+.nsg-nav-item:focus,
+.nsg-nav-item:active {
   color: var(--secondary-color-800);
 }
 
-.nav-item:hover::before,
-.nav-item:focus::before,
-.nav-item:active::before {
+.nsg-nav-item:hover::before,
+.nsg-nav-item:focus::before,
+.nsg-nav-item:active::before {
   opacity: 1;
 }
 </style>

--- a/packages/nuxt-styleguide-renderer-default/pages/icons/index.vue
+++ b/packages/nuxt-styleguide-renderer-default/pages/icons/index.vue
@@ -1,7 +1,7 @@
 <template>
   <sg-frame>
     <h1>All Icons</h1>
-    <div class="iconGrid">
+    <div class="nsg-iconGrid">
       <div
         v-for="(icon) in icons"
         :key="icon.path"
@@ -52,7 +52,7 @@ export default {
 </script>
 
 <style>
-.iconGrid {
+.nsg-iconGrid {
   width: 100%;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));

--- a/packages/nuxt-styleguide-renderer-default/pages/index.vue
+++ b/packages/nuxt-styleguide-renderer-default/pages/index.vue
@@ -12,7 +12,7 @@ import SgFrame from '../frame.vue'
 
 export default {
   layout(context) {
-    return context.env.nsgLayout
+    return context.env.nsgLayout || 'NsgDefault'
   },
   components: {
     SgFrame,

--- a/packages/nuxt-styleguide-renderer-default/vars.scss
+++ b/packages/nuxt-styleguide-renderer-default/vars.scss
@@ -1,5 +1,0 @@
-$grey: #d3d3d3;
-$blueColor: #0785b9;
-$turquoiseColor: #55b0b7;
-
-$sidebarWidth: 250px;


### PR DESCRIPTION
in order to avoid generic classnames being styled by global styles from the project CSS

Example: Bootstrap uses a `.nav` class that would apply its styles. With this change, the classes used are scoped with `nsg-` to avoid these cases.

This also:

- renames the default template to not interfere with a projects default layout.
- uses `require` for `prism.css` to make sure it is included correctly when used in projects. <= this one is a guess, though :-/